### PR TITLE
Only match entities not embedded in links

### DIFF
--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -554,30 +554,7 @@ https://host.com/2.jpeg
                     "type": "link",
                   },
                 ],
-                "text": "https://github.com/",
-                "type": "text",
-              },
-              {
-                "attrs": {
-                  "nprofile": "nostr:npub1cesrkrcuelkxyhvupzm48e8hwn4005w0ya5jyvf9kh75mfegqx0q4kt37c",
-                  "pubkey": "c6603b0f1ccfec625d9c08b753e4f774eaf7d1cf2769223125b5fd4da728019e",
-                  "relays": [],
-                },
-                "type": "nprofile",
-              },
-              {
-                "marks": [
-                  {
-                    "attrs": {
-                      "class": null,
-                      "href": "https://github.com/nostr:npub1cesrkrcuelkxyhvupzm48e8hwn4005w0ya5jyvf9kh75mfegqx0q4kt37c/wrong/link/",
-                      "rel": "noopener noreferrer nofollow",
-                      "target": "_blank",
-                    },
-                    "type": "link",
-                  },
-                ],
-                "text": "/wrong/link/",
+                "text": "https://github.com/nostr:npub1cesrkrcuelkxyhvupzm48e8hwn4005w0ya5jyvf9kh75mfegqx0q4kt37c/wrong/link/",
                 "type": "text",
               },
               {
@@ -596,37 +573,7 @@ https://host.com/2.jpeg
                     "type": "link",
                   },
                 ],
-                "text": "https://github.com/",
-                "type": "text",
-              },
-            ],
-            "type": "paragraph",
-          },
-          {
-            "attrs": {
-              "author": "0a5a87baeead12b08c0c026caa46c009bb533aae1bd1681f52d609dd2b6fd8bc",
-              "id": "2ceb90d42ab5a19b76dddfbda45687bc8011917a41286783edd14ca690fd86ee",
-              "kind": null,
-              "nevent": "nostr:nevent1qgsq5k58hth26y4s3sxqym92gmqqnw6n82hph5tgrafdvzwa9dha30qqyqkwhyx59266rxmkmh0mmfzks77gqyv30fqjseurahg5ef5slkrwuzwpwzp",
-              "relays": [],
-            },
-            "type": "nevent",
-          },
-          {
-            "content": [
-              {
-                "marks": [
-                  {
-                    "attrs": {
-                      "class": null,
-                      "href": "https://github.com/nostr:nevent1qgsq5k58hth26y4s3sxqym92gmqqnw6n82hph5tgrafdvzwa9dha30qqyqkwhyx59266rxmkmh0mmfzks77gqyv30fqjseurahg5ef5slkrwuzwpwzp/error",
-                      "rel": "noopener noreferrer nofollow",
-                      "target": "_blank",
-                    },
-                    "type": "link",
-                  },
-                ],
-                "text": "/error",
+                "text": "https://github.com/nostr:nevent1qgsq5k58hth26y4s3sxqym92gmqqnw6n82hph5tgrafdvzwa9dha30qqyqkwhyx59266rxmkmh0mmfzks77gqyv30fqjseurahg5ef5slkrwuzwpwzp/error",
                 "type": "text",
               },
               {

--- a/src/extensions/Bolt11Extension.ts
+++ b/src/extensions/Bolt11Extension.ts
@@ -5,7 +5,7 @@ import { decode } from 'light-bolt11-decoder'
 import type { MarkdownSerializerState } from 'prosemirror-markdown'
 import { createPasteRuleMatch } from '../helpers/utils'
 
-const LNBC_REGEX = /(?:^|\s)(lnbc[0-9a-z]{10,})/g
+const LNBC_REGEX = /(?<![\w./:?=])(lnbc[0-9a-z]{10,})/g
 
 export interface Bolt11Attributes {
   lnbc: string

--- a/src/extensions/Bolt11Extension.ts
+++ b/src/extensions/Bolt11Extension.ts
@@ -5,7 +5,7 @@ import { decode } from 'light-bolt11-decoder'
 import type { MarkdownSerializerState } from 'prosemirror-markdown'
 import { createPasteRuleMatch } from '../helpers/utils'
 
-const LNBC_REGEX = /(lnbc[0-9a-z]{10,})/g
+const LNBC_REGEX = /(?:^|\s)(lnbc[0-9a-z]{10,})/g
 
 export interface Bolt11Attributes {
   lnbc: string

--- a/src/extensions/NAddrExtension.ts
+++ b/src/extensions/NAddrExtension.ts
@@ -5,7 +5,7 @@ import type { AddressPointer } from 'nostr-tools/nip19'
 import type { MarkdownSerializerState } from 'prosemirror-markdown'
 import { createPasteRuleMatch, parseRelayAttribute } from '../helpers/utils'
 
-export const NADDR_REGEX = /(?:^|\s)(nostr:)?(naddr1[0-9a-z]+)/g
+export const NADDR_REGEX = /(?<![\w./:?=])(nostr:)?(naddr1[0-9a-z]+)/g
 
 export interface NAddrAttributes {
   naddr: string

--- a/src/extensions/NAddrExtension.ts
+++ b/src/extensions/NAddrExtension.ts
@@ -5,7 +5,7 @@ import type { AddressPointer } from 'nostr-tools/nip19'
 import type { MarkdownSerializerState } from 'prosemirror-markdown'
 import { createPasteRuleMatch, parseRelayAttribute } from '../helpers/utils'
 
-export const NADDR_REGEX = /(nostr:)?(naddr1[0-9a-z]+)/g
+export const NADDR_REGEX = /(?:^|\s)(nostr:)?(naddr1[0-9a-z]+)/g
 
 export interface NAddrAttributes {
   naddr: string

--- a/src/extensions/NEventExtension.ts
+++ b/src/extensions/NEventExtension.ts
@@ -5,9 +5,9 @@ import type { EventPointer } from 'nostr-tools/nip19'
 import type { MarkdownSerializerState } from 'prosemirror-markdown'
 import { createPasteRuleMatch, parseRelayAttribute } from '../helpers/utils'
 
-export const NOTE_REGEX = /(nostr:)?(note1[0-9a-z]+)/g
+export const NOTE_REGEX = /(?:^|\s)(nostr:)?(note1[0-9a-z]+)/g
 
-export const NEVENT_REGEX = /(nostr:)?(nevent1[0-9a-z]+)/g
+export const NEVENT_REGEX = /(?:^|\s)(nostr:)?(nevent1[0-9a-z]+)/g
 
 export interface NEventAttributes {
   nevent: string

--- a/src/extensions/NEventExtension.ts
+++ b/src/extensions/NEventExtension.ts
@@ -5,9 +5,9 @@ import type { EventPointer } from 'nostr-tools/nip19'
 import type { MarkdownSerializerState } from 'prosemirror-markdown'
 import { createPasteRuleMatch, parseRelayAttribute } from '../helpers/utils'
 
-export const NOTE_REGEX = /(?:^|\s)(nostr:)?(note1[0-9a-z]+)/g
+export const NOTE_REGEX = /(?<![\w./:?=])(nostr:)?(note1[0-9a-z]+)/g
 
-export const NEVENT_REGEX = /(?:^|\s)(nostr:)?(nevent1[0-9a-z]+)/g
+export const NEVENT_REGEX = /(?<![\w./:?=])(nostr:)?(nevent1[0-9a-z]+)/g
 
 export interface NEventAttributes {
   nevent: string

--- a/src/extensions/NProfileExtension.ts
+++ b/src/extensions/NProfileExtension.ts
@@ -5,9 +5,9 @@ import type { ProfilePointer } from 'nostr-tools/nip19'
 import type { MarkdownSerializerState } from 'prosemirror-markdown'
 import { createPasteRuleMatch, parseRelayAttribute } from '../helpers/utils'
 
-export const NPUB_REGEX = /(?:^|\s)(nostr:)?(npub1[0-9a-z]+)/g
+export const NPUB_REGEX = /(?<![\w./:?=])(nostr:)?(npub1[0-9a-z]+)/g
 
-export const NPROFILE_REGEX = /(?:^|\s)(nostr:)?(nprofile1[0-9a-z]+)/g
+export const NPROFILE_REGEX = /(?<![\w./:?=])(nostr:)?(nprofile1[0-9a-z]+)/g
 
 export type NProfileAttributes = {
   nprofile: string

--- a/src/extensions/NProfileExtension.ts
+++ b/src/extensions/NProfileExtension.ts
@@ -5,9 +5,9 @@ import type { ProfilePointer } from 'nostr-tools/nip19'
 import type { MarkdownSerializerState } from 'prosemirror-markdown'
 import { createPasteRuleMatch, parseRelayAttribute } from '../helpers/utils'
 
-export const NPUB_REGEX = /(nostr:)?(npub1[0-9a-z]+)/g
+export const NPUB_REGEX = /(?:^|\s)(nostr:)?(npub1[0-9a-z]+)/g
 
-export const NPROFILE_REGEX = /(nostr:)?(nprofile1[0-9a-z]+)/g
+export const NPROFILE_REGEX = /(?:^|\s)(nostr:)?(nprofile1[0-9a-z]+)/g
 
 export type NProfileAttributes = {
   nprofile: string


### PR DESCRIPTION
Before this change, pasting njump links would trigger the entity regexp. This ensures only entities surrounded by a space or the beginning/end of a string will get matched.