### PR TITLE
add typeguards and export types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -16,75 +16,107 @@ export type ParagraphNode = {
   content?: Node[]
 }
 
+export const isParagraphNode = (node: Node): node is ParagraphNode => node.type === 'paragraph'
+
 export type TextNode = {
   type: Extensions<'text'>
   marks?: Mark[]
   text: string
 }
 
+export const isTextNode = (node: Node): node is TextNode => node.type === 'text'
+
 export type HardBreak = {
   type: Extensions<'hardBreak'>
 }
+
+export const isHardBreak = (node: Node): node is HardBreak => node.type === 'hardBreak'
 
 export type HorizontalRule = {
   type: Extensions<'horizontalRule'>
 }
 
-type TagMark = {
+export const isHorizontalRule = (node: Node): node is HorizontalRule => node.type === 'horizontalRule'
+
+export type TagMark = {
   type: 'tag'
   attrs: TagAttributes
 }
 
-type LinkMark = {
+export const isTagMark = (mark: Mark): mark is TagMark => mark.type === 'tag'
+
+export type LinkMark = {
   type: 'link'
   attrs: LinkAttributes
 }
 
-type CodeMark = {
+export const isLinkMark = (mark: Mark): mark is LinkMark => mark.type === 'link'
+
+export type CodeMark = {
   type: 'code'
 }
 
-type ItalicMark = {
+export const isCodeMark = (mark: Mark): mark is CodeMark => mark.type === 'code'
+
+export type ItalicMark = {
   type: 'italic'
 }
 
-type BoldMark = {
+export const isItalicMark = (mark: Mark): mark is ItalicMark => mark.type === 'italic'
+
+export type BoldMark = {
   type: 'bold'
 }
 
-type StrikeMark = {
+export const isBoldMark = (mark: Mark): mark is BoldMark => mark.type === 'bold'
+
+export type StrikeMark = {
   type: 'strike'
 }
+
+export const isStrikeMark = (mark: Mark): mark is StrikeMark => mark.type === 'strike'
 
 export type NProfileNode = {
   type: 'nprofile'
   attrs: NProfileAttributes
 }
 
+export const isNProfileNode = (node: Node): node is NProfileNode => node.type === 'nprofile'
+
 export type NEventNode = {
   type: 'nevent'
   attrs: NEventAttributes
 }
+
+export const isNEventNode = (node: Node): node is NEventNode => node.type === 'nevent'
 
 export type NAddrNode = {
   type: 'naddr'
   attrs: NAddrAttributes
 }
 
+export const isNAddrNode = (node: Node): node is NAddrNode => node.type === 'naddr'
+
 export type ImageNode = {
   type: 'image'
   attrs: ImageOptions['HTMLAttributes']
 }
+
+export const isImageNode = (node: Node): node is ImageNode => node.type === 'image'
 
 export type VideoNode = {
   type: 'video'
   attrs: VideoAttributes
 }
 
+export const isVideoNode = (node: Node): node is VideoNode => node.type === 'video'
+
 export type Bolt11Node = {
   type: 'bolt11'
   attrs: Bolt11Attributes
 }
+
+export const isBolt11Node = (node: Node): node is Bolt11Node => node.type === 'bolt11'
 
 export type HeadingNode = {
   type: Extensions<'heading'>
@@ -94,7 +126,9 @@ export type HeadingNode = {
   }
 }
 
-type ListItemNode = {
+export const isHeadingNode = (node: Node): node is HeadingNode => node.type === 'heading'
+
+export type ListItemNode = {
   type: Extensions<'listItem'>
   content: Node[]
   attrs: {
@@ -108,10 +142,14 @@ export type BulletListNode = {
   content: ListItemNode[]
 }
 
+export const isBulletListNode = (node: Node): node is BulletListNode => node.type === 'bulletList'
+
 export type OrderedListNode = {
   type: Extensions<'orderedList'>
   content: ListItemNode[]
 }
+
+export const isOrderedListNode = (node: Node): node is OrderedListNode => node.type === 'orderedList'
 
 export type CodeBlockNode = {
   type: Extensions<'codeBlock'>
@@ -121,15 +159,21 @@ export type CodeBlockNode = {
   }
 }
 
+export const isCodeBlockNode = (node: Node): node is CodeBlockNode => node.type === 'codeBlock'
+
 export type BlockQuoteNode = {
   type: Extensions<'blockquote'>
   content: Node[]
 }
 
+export const isBlockQuoteNode = (node: Node): node is BlockQuoteNode => node.type === 'blockquote'
+
 type TweetNode = {
   type: 'tweet'
   attrs: TweetAttributes
 }
+
+export const isTweetNode = (node: Node): node is TweetNode => node.type === 'tweet'
 
 type YoutubeNode = {
   type: 'youtube'
@@ -140,6 +184,8 @@ type YoutubeNode = {
     start?: number
   }
 }
+
+export const isYoutubeNode = (node: Node): node is YoutubeNode => node.type === 'youtube'
 
 export type Mark = TagMark | LinkMark | CodeMark | ItalicMark | BoldMark | StrikeMark
 


### PR DESCRIPTION
the rational for needing these types:

I want to keep consistency between rendering of content in editor mode and normal mode, however I also want more efficient rendering for read-only content than tiptap offers. I'm using tiptap `Editor` to generate the document tree and then render that directly with svelte.