### PR TITLE
Enrich removeBlobs command

### DIFF
--- a/src/__tests__/upload.test.ts
+++ b/src/__tests__/upload.test.ts
@@ -102,7 +102,10 @@ describe('FileUpload', () => {
     expect(spyUpload).toHaveBeenCalledOnce()
     expect(spyUpload).toHaveBeenCalledWith(editor, res1)
     expect(spyUploadError).toHaveBeenCalledOnce()
-    expect(spyUploadError).toHaveBeenCalledWith(editor, { uploadError: 'Error: Invalid file' })
+    expect(spyUploadError).toHaveBeenCalledWith(editor, {
+      uploadError: 'Error: Invalid file',
+      url: 'https://localhost:3000',
+    })
     expect(spyComplete).not.toHaveBeenCalledOnce()
   })
 


### PR DESCRIPTION
As discussed in the previous PR. There should be an option to remove either all blobs in the editor, or only those that have failed. The removeBlobs command now has an errorsOnly parameter (default to false)

Also adding the url endpoint that failed in the file object parameter passed in onUploadError callback