### PR TITLE
Encode response url

### DIFF
--- a/src/extensions/FileUploadExtension.ts
+++ b/src/extensions/FileUploadExtension.ts
@@ -213,7 +213,7 @@ class Uploader {
       if (node.attrs.src === nodeRef.attrs.src) {
         this.updateNodeAttributes(pos, {
           ...response,
-          src: response.url,
+          src: encodeURI(response.url),
           uploading: false,
         })
       }


### PR DESCRIPTION
coracle-social/coracle#559 

A user is using a nip-96 endpoints that returns unencoded endpoint URL.

- this PR simply ensure that the returned endpoint is a valid endpoint URL.