### PR TITLE
Add encrypted blossom uploads

### DIFF
--- a/examples/react/pnpm-lock.yaml
+++ b/examples/react/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       luxon:
         specifier: ^3.4.4
         version: 3.4.4
-      nostr-editor:
-        specifier: link:../..
-        version: link:../..
       nostr-tools:
         specifier: ^2.7.2
         version: 2.7.2(typescript@5.5.4)

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -182,6 +182,7 @@ function App() {
             defaultUploadType: 'nip96',
           },
           fileUpload: settings.fileUpload !== false && {
+            encryptionAlgorithm: 'aes-gcm',
             immediateUpload: false,
             sign: async (event) => {
               if ('nostr' in window) {

--- a/examples/react/src/components/Content.tsx
+++ b/examples/react/src/components/Content.tsx
@@ -25,8 +25,8 @@ export const Content = function Content(props: Props) {
             {node.type === 'heading' && <Heading node={node} />}
             {node.type === 'paragraph' && <Paragraph node={node} />}
             {node.type === 'horizontalRule' && <hr className='mt-6 mb-6' />}
-            {node.type === 'image' && <Image src={node.attrs.src} />}
-            {node.type === 'video' && <Video src={node.attrs.src} />}
+            {node.type === 'image' && <Image src={node.attrs.src} tags={node.attrs.tags} />}
+            {node.type === 'video' && <Video src={node.attrs.src} tags={node.attrs.tags} />}
             {node.type === 'nevent' && <NEvent {...node.attrs} />}
             {node.type === 'orderedList' && <List type='ol' node={node} />}
             {node.type === 'bulletList' && <List type='ul' node={node} />}

--- a/examples/react/src/components/Image/Image.tsx
+++ b/examples/react/src/components/Image/Image.tsx
@@ -1,12 +1,78 @@
+import { useState, useEffect } from 'react'
+import { Base64 } from 'js-base64'
+import { decryptFile } from 'nostr-editor'
+
 type Props = {
   src: string
+  tags?: string[][]
 }
 
 export function Image(props: Props) {
-  const { src } = props
+  const { src, tags } = props
+  const [imageSrc, setImageSrc] = useState<string>(src)
+  const [isDecrypting, setIsDecrypting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const encryptionAlgorithm = tags?.find(tag => tag[0] === 'encryption-algorithm')?.[1]
+    const key = tags?.find(tag => tag[0] === 'decryption-key')?.[1]
+    const nonce = tags?.find(tag => tag[0] === 'decryption-nonce')?.[1]
+
+    if (encryptionAlgorithm === 'aes-gcm') {
+      if (key && nonce) {
+        decryptAndSetImage(src, encryptionAlgorithm, key, nonce)
+      } else {
+        setError('Missing decryption key or nonce')
+      }
+    }
+  }, [src, tags])
+
+  const decryptAndSetImage = async (src: string, encryptionAlgorithm: string, key: string, nonce: string) => {
+    try {
+      setIsDecrypting(true)
+      setError(null)
+
+      // Fetch the encrypted image data
+      const response = await fetch(src)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch encrypted image: ${response.statusText}`)
+      }
+
+      const ciphertext = new Uint8Array(await response.arrayBuffer())
+      const decryptedData = decryptFile({ciphertext, key, nonce, encryptionAlgorithm})
+      const blobUrl = URL.createObjectURL(new Blob([new Uint8Array(decryptedData)]))
+
+      setImageSrc(blobUrl)
+
+      // Clean up the blob URL when component unmounts
+      return () => URL.revokeObjectURL(blobUrl)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to decrypt image')
+    } finally {
+      setIsDecrypting(false)
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="max-h-80 rounded-lg my-2 bg-red-100 border border-red-400 text-red-700 px-4 py-3">
+        <strong className="font-bold">Error: </strong>
+        <span className="block sm:inline">{error}</span>
+      </div>
+    )
+  }
+
+  if (isDecrypting) {
+    return (
+      <div className="max-h-80 rounded-lg my-2 bg-gray-100 border border-gray-300 px-4 py-3 flex items-center justify-center">
+        <span>Decrypting image...</span>
+      </div>
+    )
+  }
+
   return (
     <>
-      <img src={src} className='max-h-80 rounded-lg my-2' />
+      <img src={imageSrc} className='max-h-80 rounded-lg my-2' />
     </>
   )
 }

--- a/examples/react/src/components/Image/ImageEditor.tsx
+++ b/examples/react/src/components/Image/ImageEditor.tsx
@@ -10,7 +10,7 @@ import { UploadingProgress } from '../UploadingProgress'
 import { Image } from './Image'
 
 export function ImageEditor(props: NodeViewProps) {
-  const { src, alt, uploadUrl, uploading, uploadError } = props.node.attrs as ImageAttributes
+  const { src, alt, uploadUrl, uploading, uploadError, tags } = props.node.attrs as ImageAttributes
   const isUploaded = !src.startsWith('blob:http')
   return (
     <NodeViewWrapper
@@ -19,7 +19,7 @@ export function ImageEditor(props: NodeViewProps) {
       className={`relative my-2 [&>img]:m-0 w-fit h-fit ${props.selected ? 'opacity-90' : ''}`}>
       <DeleteButton onClick={() => props.deleteNode()} />
       <UploadingProgress uploading={uploading} />
-      <Image src={src} />
+      <Image src={src} tags={tags} />
       <MediaFooter>
         {!isUploaded && <AltButton value={alt} onChange={(alt) => props.updateAttributes({ alt })} />}
         {!isUploaded && (

--- a/examples/react/src/components/UploadChip.tsx
+++ b/examples/react/src/components/UploadChip.tsx
@@ -10,6 +10,8 @@ type Props = {
 
 const nip96urls = ['https://nostr.build', 'https://nostrcheck.me', 'https://nostrage.com']
 
+const blossomurls = ['https://cdn.satellite.earth']
+
 function Item(props: { url: string; onClick: () => void }) {
   const { url, onClick } = props
   return (
@@ -50,13 +52,16 @@ export function UploadChip(props: Props) {
             </ul>
             <span className='p-2 font-bold'>Blossom Servers:</span>
             <ul className='m-0 mb-1 list-none'>
-              <Item
-                url='http://localhost:3000'
-                onClick={() => {
-                  onChange('blossom', 'http://localhost:3000')
-                  setOpen(false)
-                }}
-              />
+              {blossomurls.map((url) => (
+                <Item
+                  key={url}
+                  url={url}
+                  onClick={() => {
+                    onChange('blossom', url)
+                    setOpen(false)
+                  }}
+                />
+              ))}
             </ul>
           </div>
         }>

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "tiptap-markdown": "^0.8.10"
   },
   "dependencies": {
+    "@noble/ciphers": "^1.3.0",
+    "@noble/hashes": "^1.8.0",
     "js-base64": "^3.7.7",
     "light-bolt11-decoder": "^3.1.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@noble/ciphers':
+        specifier: ^1.3.0
+        version: 1.3.0
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@tiptap/core':
         specifier: ^2.6.6
         version: 2.11.5(@tiptap/pm@2.11.5)
@@ -370,6 +376,10 @@ packages:
   '@noble/ciphers@0.5.3':
     resolution: {integrity: sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==}
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.1.0':
     resolution: {integrity: sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==}
 
@@ -383,6 +393,10 @@ packages:
   '@noble/hashes@1.3.2':
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
     engines: {node: '>= 16'}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2079,6 +2093,8 @@ snapshots:
 
   '@noble/ciphers@0.5.3': {}
 
+  '@noble/ciphers@1.3.0': {}
+
   '@noble/curves@1.1.0':
     dependencies:
       '@noble/hashes': 1.3.1
@@ -2090,6 +2106,8 @@ snapshots:
   '@noble/hashes@1.3.1': {}
 
   '@noble/hashes@1.3.2': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/src/extensions/FileUploadExtension.ts
+++ b/src/extensions/FileUploadExtension.ts
@@ -34,6 +34,7 @@ export interface FileUploadOptions {
   onUpload: (currentEditor: Editor, file: UploadTask) => void
   onUploadError: (currentEditor: Editor, file: UploadTask) => void
   onComplete: (currentEditor: Editor, files: FileAttributes[]) => void
+  encryptionAlgorithm?: "aes-gcm"
 }
 
 export interface FileUploadStorage {
@@ -232,7 +233,7 @@ class Uploader {
   }
 
   private async upload(node: Node, pos: number) {
-    const { sign, hash, expiration } = this.options
+    const { sign, hash, expiration, encryptionAlgorithm } = this.options
     const { file, alt, uploadType, uploadUrl: serverUrl } = node.attrs as ImageAttributes | VideoAttributes
 
     this.updateNodeAttributes(pos, { uploading: true, uploadError: null })
@@ -242,7 +243,7 @@ class Uploader {
       res =
         uploadType === 'nip96'
           ? await uploadNIP96({ file, alt, sign, serverUrl })
-          : await uploadBlossom({ file, serverUrl, hash, sign, expiration })
+          : await uploadBlossom({ file, serverUrl, hash, sign, expiration, encryptionAlgorithm })
     } catch (error) {
       const msg = error?.toString() as string
       res = { uploadError: msg, url: serverUrl } as UploadTask

--- a/src/uploaders/blossom.ts
+++ b/src/uploaders/blossom.ts
@@ -1,4 +1,7 @@
 import { Base64 } from 'js-base64'
+import {hexToBytes, bytesToHex} from "@noble/hashes/utils"
+import { gcm } from '@noble/ciphers/aes'
+import { randomBytes } from '@noble/ciphers/webcrypto'
 import type { EventTemplate, NostrEvent } from 'nostr-tools/core'
 import type { UploadTask } from './types'
 
@@ -8,6 +11,7 @@ export interface BlossomOptions {
   expiration?: number
   hash?: (file: File) => Promise<string>
   sign?: (event: EventTemplate) => Promise<NostrEvent> | NostrEvent
+  encryptionAlgorithm?: 'aes-gcm'
 }
 
 export interface BlossomResponse {
@@ -23,6 +27,44 @@ export interface BlossomResponseError {
   message: string
 }
 
+export interface EncryptionResult {
+  key: string
+  nonce: string
+  ciphertext: Uint8Array
+}
+
+export async function encryptFile({encryptionAlgorithm, file}: BlossomOptions): Promise<EncryptionResult> {
+  if (encryptionAlgorithm !== 'aes-gcm') {
+    throw new Error(`Unsupported encryption algorithm: ${encryptionAlgorithm}`)
+  }
+
+  const keyBytes = randomBytes(32)
+  const nonceBytes = randomBytes(12)
+  const key = bytesToHex(keyBytes)
+  const nonce = bytesToHex(nonceBytes)
+  const fileBuffer = await file.arrayBuffer()
+  const fileData = new Uint8Array(fileBuffer)
+  const cipher = gcm(keyBytes, nonceBytes)
+  const ciphertext = cipher.encrypt(fileData)
+
+  return {ciphertext, key, nonce}
+}
+
+export interface DecryptionOptions extends EncryptionResult {
+  encryptionAlgorithm: string
+}
+
+export function decryptFile({encryptionAlgorithm, key, nonce, ciphertext}: DecryptionOptions): Uint8Array {
+  if (encryptionAlgorithm !== 'aes-gcm') {
+    throw new Error(`Unsupported encryption algorithm: ${encryptionAlgorithm}`)
+  }
+
+  const cipher = gcm(hexToBytes(key), hexToBytes(nonce))
+  const decryptedData = cipher.decrypt(ciphertext)
+
+  return decryptedData
+}
+
 const mapUrlWithExtension = (url: string) => (tag: string[]) => (tag[0] === 'url' ? [tag[0], url] : tag)
 
 export async function uploadBlossom(options: BlossomOptions): Promise<UploadTask> {
@@ -32,26 +74,37 @@ export async function uploadBlossom(options: BlossomOptions): Promise<UploadTask
   if (!options.sign) {
     throw new Error('No signer provided')
   }
+
+  let file: File = options.file
+  let encryptionResult: EncryptionResult | undefined = undefined
+
+  if (options.encryptionAlgorithm) {
+    encryptionResult = await encryptFile(options)
+    const blob = new Blob([encryptionResult.ciphertext])
+
+    file = new File([blob], file.name, {type: file.type})
+  }
+
   const now = Math.floor(Date.now() / 1000)
-  const hash = await options.hash(options.file)
   const event = await options.sign({
     kind: 24242,
-    content: `Upload ${options.file.name}`,
+    content: `Upload ${file.name}`,
     created_at: now,
     tags: [
       ['u', options.serverUrl],
       ['method', 'PUT'],
       ['t', 'upload'],
-      ['x', hash],
-      ['size', options.file.size.toString()],
       ['expiration', Math.floor(now + (options.expiration || 60000)).toString()],
+      ['x', await options.hash(file)],
+      ['size', file.size.toString()],
     ],
   })
+
   const base64 = Base64.encode(JSON.stringify(event))
   const authorization = `Nostr ${base64}`
   const res = await fetch(options.serverUrl + '/upload', {
     method: 'PUT',
-    body: options.file,
+    body: file,
     headers: {
       authorization,
     },
@@ -65,13 +118,21 @@ export async function uploadBlossom(options: BlossomOptions): Promise<UploadTask
   // Always append file extension if missing
   const { pathname } = new URL(json.url)
   const hasExtension = pathname.split('.').length === 2
-  const extension = '.' + options.file.type.split('/')[1]
+  const extension = '.' + file.type.split('/')[1]
   const url = json.url + (hasExtension ? '' : extension)
-  return {
-    ...json,
-    url,
-    tags: Array.isArray(nip94)
+  const tags = Array.isArray(nip94)
       ? nip94.map(mapUrlWithExtension(url))
-      : Array.from(Object.entries(nip94 || {})).map(mapUrlWithExtension(url)),
+      : Object.entries(nip94 || {}).map(mapUrlWithExtension(url))
+  const result = {...json, url, tags}
+
+  // Add encryption metadata to the result if file was encrypted
+  if (encryptionResult && options.encryptionAlgorithm) {
+    tags.push(
+      ['decryption-key', encryptionResult.key],
+      ['decryption-nonce', encryptionResult.nonce],
+      ['encryption-algorithm', options.encryptionAlgorithm],
+    )
   }
+
+  return result
 }


### PR DESCRIPTION
I still have to write a NIP PR to document this. It's based on https://github.com/nostr-protocol/nips/blob/master/17.md's kind 15, but allows for the same tags to be placed in imeta defined in https://github.com/nostr-protocol/nips/blob/master/92.md. The use case is for image attachments in DMs and private groups.