### PR TITLE
Prevent default paste handling when an image is detected on paste

### DIFF
--- a/src/extensions/FileUploadExtension.ts
+++ b/src/extensions/FileUploadExtension.ts
@@ -145,16 +145,22 @@ export const FileUploadExtension = Extension.create<FileUploadOptions, FileUploa
         },
         props: {
           handleDrop: (_, event) => {
-            uploader.handleDrop(event)
+            const handled = uploader.handleDrop(event)
+
             if (this.options.immediateUpload) {
               uploader.start()
             }
+
+            return handled
           },
           handlePaste: (_, event) => {
-            uploader.handlePaste(event)
-            if (this.options.immediateUpload) {
+            const handled = uploader.handlePaste(event)
+
+            if (handled && this.options.immediateUpload) {
               uploader.start()
             }
+
+            return handled
           },
         },
       }),
@@ -305,12 +311,16 @@ class Uploader {
 
     const pos = this.view.posAtCoords({ left: event.clientX, top: event.clientY })?.pos
 
-    if (!pos) return
-    if (!event.dataTransfer) return
+    if (!pos) return false
+    if (!event.dataTransfer) return false
 
+    let handled = false
     for (const file of event.dataTransfer.files) {
       this.addFile(file, pos)
+      handled = true
     }
+
+    return handled
   }
 
   handlePaste(event: ClipboardEvent) {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -54,8 +54,10 @@ export function replaceTextContent(content: string): string {
  * From: https://stackoverflow.com/q/79019919/1467342
  */
 function handlePaste(view: EditorView, event: ClipboardEvent) {
-  // Prevent the default paste behavior
-  event.preventDefault()
+  // If there are files, let the FileUploadExtension handle them
+  if (event.clipboardData?.files && event.clipboardData.files.length > 0) {
+    return false
+  }
 
   // Get plain text from clipboard
   const text = event.clipboardData?.getData('text/plain')
@@ -80,7 +82,7 @@ function handlePaste(view: EditorView, event: ClipboardEvent) {
     view.dispatch(tr.scrollIntoView().setMeta('paste', true).setMeta('uiEvent', 'paste'))
   }
 
-  return true
+  return Boolean(text)
 }
 
 /**


### PR DESCRIPTION
This fixes an issue where if you click "copy image" and then paste in an editor it would show the image's url as well as trigger the upload handler. The onDrop changes are just for consistency, I don't think they make any difference, but they might if drop handlers are overloaded.