### PR TITLE
Let ProseMirror handle paste natively inside code blocks to preserve newlines

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -59,6 +59,12 @@ function handlePaste(view: EditorView, event: ClipboardEvent) {
     return false
   }
 
+  // Let ProseMirror handle paste natively inside code blocks to preserve newlines
+  const { $from } = view.state.selection
+  if ($from.parent.type.spec.code) {
+    return false
+  }
+
   // Get plain text from clipboard
   const text = event.clipboardData?.getData('text/plain')
 


### PR DESCRIPTION
Before, if you pasted multiple lines into a code block, it would split each line into its own code block.
<img width="475" height="192" alt="Screenshot 2026-02-25 at 1 23 13 PM" src="https://github.com/user-attachments/assets/62227380-f8b9-411c-8cb7-d7265f43f129" />
